### PR TITLE
update to ef3.x and latest nuget packages

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -69,4 +69,4 @@ cache:
 deploy:
 - provider: NuGet
   api_key:
-    secure: w5Ze2msHkcTFwH4T9Etikd0pXBy6vjtkwCTbvmlG3yNTuSkiKgsapR0mwxD1+f1v
+    secure: NK6JEky2i7+06Ij+PlJX7X0xlKT4fg2zDIFP5fiFSy6EqxcIYThFBkzzqpQTUnsO

--- a/src/Cortside.Health.Tests/Cortside.Health.Tests.csproj
+++ b/src/Cortside.Health.Tests/Cortside.Health.Tests.csproj
@@ -4,15 +4,18 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="Moq" Version="4.15.1" />
+    <PackageReference Include="FluentAssertions" Version="6.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Cortside.Health\Cortside.Health.csproj" />

--- a/src/Cortside.Health.Tests/Cortside.Health.Tests.csproj
+++ b/src/Cortside.Health.Tests/Cortside.Health.Tests.csproj
@@ -7,8 +7,11 @@
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Moq" Version="4.15.1" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="coverlet.collector" Version="1.2.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Cortside.Health/Checks/DbContextCheck.cs
+++ b/src/Cortside.Health/Checks/DbContextCheck.cs
@@ -29,7 +29,7 @@ namespace Cortside.Health.Checks {
                     // only do actual test to conext if the db is not the in memory provider
                     if (context.Database.ProviderName != "Microsoft.EntityFrameworkCore.InMemory") {
                         context.Database.SetCommandTimeout(check.Timeout);
-                        await context.Database.ExecuteSqlCommandAsync("select @@VERSION");
+                        await context.Database.ExecuteSqlRawAsync("select @@VERSION").ConfigureAwait(false);
                     }
 
                     serviceStatusModel.Healthy = true;

--- a/src/Cortside.Health/Cortside.Health.csproj
+++ b/src/Cortside.Health/Cortside.Health.csproj
@@ -5,15 +5,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cortside.Common.Correlation" Version="1.0.165" />
-    <PackageReference Include="Cortside.Common.Hosting" Version="1.0.165" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.15.0" />
+    <PackageReference Include="Cortside.Common.Correlation" Version="1.0.195" />
+    <PackageReference Include="Cortside.Common.Hosting" Version="1.0.195" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.19.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="4.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.7" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.21" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.21" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0" />
-    <PackageReference Include="RestSharp" Version="106.6.10" />
+    <PackageReference Include="RestSharp" Version="106.13.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Cortside.Health/Cortside.Health.csproj
+++ b/src/Cortside.Health/Cortside.Health.csproj
@@ -9,10 +9,10 @@
     <PackageReference Include="Cortside.Common.Hosting" Version="1.0.165" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.15.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="4.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.2.6" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0" />
     <PackageReference Include="RestSharp" Version="106.6.10" />
   </ItemGroup>
 

--- a/update-nugetpackages.ps1
+++ b/update-nugetpackages.ps1
@@ -1,0 +1,7 @@
+[cmdletBinding()]
+param(
+	[switch]$update=[switch]::Present
+)
+
+dotnet tool update --global dotnet-outdated-tool
+dotnet outdated ./src --version-lock Major -u


### PR DESCRIPTION
update ef to 3.x, which allows consumers to use ef3.x or ef5.x without issue