### PR TITLE
Add MonitoredHostedServiceCheck

### DIFF
--- a/src/Cortside.Health.Tests/CheckFactoryTest.cs
+++ b/src/Cortside.Health.Tests/CheckFactoryTest.cs
@@ -1,10 +1,10 @@
 using Cortside.Health.Checks;
-using Shouldly;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Moq;
+using Shouldly;
 using Xunit;
 
 namespace Cortside.Health.Tests {
@@ -33,6 +33,25 @@ namespace Cortside.Health.Tests {
             // assert
             check.ShouldNotBeNull();
         }
+
+        [Fact]
+        public void ShouldResolveMonitoredHostedServiceCheck() {
+            // assert
+            var cache = new Mock<IMemoryCache>();
+            var logger = new Mock<ILogger<Check>>();
+            var recorder = new Mock<IAvailabilityRecorder>();
+            var configuration = new Mock<IConfiguration>();
+            var sp = serviceCollection.BuildServiceProvider();
+            var factory = new CheckFactory(cache.Object, logger.Object, recorder.Object, sp, configuration.Object);
+
+            // act
+            var config = new CheckConfiguration() { Name = "foo", Type = "monitoredhostedservice" };
+            var check = factory.Create(config);
+
+            // assert
+            check.ShouldNotBeNull();
+        }
+
 
         [Fact]
         public void ShouldResolveUnresolvedCheckForNullTypeName() {

--- a/src/Cortside.Health.Tests/Hosting/MonitoredHostedConfiguration.cs
+++ b/src/Cortside.Health.Tests/Hosting/MonitoredHostedConfiguration.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace Cortside.Health.Tests.Hosting {
+    public class MonitoredHostedConfiguration {
+        public int Interval { get; set; }
+        public bool Enabled { get; set; }
+        public TimeSpan Sleep { get; set; }
+    }
+}

--- a/src/Cortside.Health.Tests/Hosting/MonitoredHostedService.cs
+++ b/src/Cortside.Health.Tests/Hosting/MonitoredHostedService.cs
@@ -1,0 +1,17 @@
+using System.Threading.Tasks;
+using Cortside.Common.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Cortside.Health.Tests.Hosting {
+    public class MonitoredHostedService : TimedHostedService, IMonitoredHostedService {
+        private readonly MonitoredHostedConfiguration config;
+
+        public MonitoredHostedService(ILogger logger, MonitoredHostedConfiguration config) : base(logger, config.Enabled, config.Interval) {
+            this.config = config;
+        }
+
+        protected override Task ExecuteIntervalAsync() {
+            return Task.Delay(config.Sleep);
+        }
+    }
+}

--- a/src/Cortside.Health.Tests/MonitoredHostedServiceTest.cs
+++ b/src/Cortside.Health.Tests/MonitoredHostedServiceTest.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Cortside.Health.Checks;
+using Cortside.Health.Tests.Hosting;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Cortside.Health.Tests {
+    public class MonitoredHostedServiceTest {
+        [Theory]
+        [InlineData(1, true, 1)]
+        [InlineData(60000, false, 10)]
+        public async Task ShouldGetHealth(int sleepMs, bool healthy, int waitDelay) {
+            // arrange
+            var logger = new NullLogger<MonitoredHostedService>();
+            var config = new MonitoredHostedConfiguration {
+                Enabled = true,
+                Interval = 1,
+                Sleep = TimeSpan.FromMilliseconds(sleepMs)
+            };
+            var service = new MonitoredHostedService(logger, config);
+
+            // act
+            var source = new CancellationTokenSource();
+            var t1 = service.StartAsync(source.Token);
+            var t2 = Task.Delay(10000);
+            await Task.WhenAll(t1, t2);
+
+            var services = new ServiceCollection();
+            services.AddSingleton<IHostedService>(service);
+            var serviceProvider = services.BuildServiceProvider();
+
+            var recorder = new Mock<IAvailabilityRecorder>();
+            var check = new MonitoredHostedServiceCheck(new MemoryCache(new MemoryCacheOptions()), new NullLogger<Check>(), serviceProvider, recorder.Object);
+            var cc = new CheckConfiguration {
+                Name = "foo",
+                Type = "monitoredhostedservice",
+                Required = true,
+                Interval = 30,
+                Timeout = 5
+            };
+            check.Initialize(cc);
+            var status = await check.ExecuteAsync();
+
+            // assert
+            Assert.Equal(healthy, status.Healthy);
+            await source.CancelAsync();
+        }
+    }
+}

--- a/src/Cortside.Health.Tests/MonitoredHostedServiceTest.cs
+++ b/src/Cortside.Health.Tests/MonitoredHostedServiceTest.cs
@@ -42,7 +42,8 @@ namespace Cortside.Health.Tests {
                 Type = "monitoredhostedservice",
                 Required = true,
                 Interval = 30,
-                Timeout = 5
+                Timeout = 5,
+                Value = waitDelay.ToString()
             };
             check.Initialize(cc);
             var status = await check.ExecuteAsync();

--- a/src/Cortside.Health/CheckFactory.cs
+++ b/src/Cortside.Health/CheckFactory.cs
@@ -22,7 +22,8 @@ namespace Cortside.Health {
             this.configuration = configuration;
             checks = new Dictionary<string, Type>() {
                 ["url"] = typeof(UrlCheck),
-                ["dbcontext"] = typeof(DbContextCheck)
+                ["dbcontext"] = typeof(DbContextCheck),
+                ["monitoredhostedservice"] = typeof(MonitoredHostedServiceCheck)
             };
         }
 

--- a/src/Cortside.Health/Checks/MonitoredHostedServiceCheck.cs
+++ b/src/Cortside.Health/Checks/MonitoredHostedServiceCheck.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Cortside.Common.Hosting;
+using Cortside.Health.Enums;
+using Cortside.Health.Models;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Cortside.Health.Checks {
+    public class MonitoredHostedServiceCheck : Check {
+        private readonly IServiceProvider serviceProvider;
+
+        public MonitoredHostedServiceCheck(IMemoryCache cache, ILogger<Check> logger, IServiceProvider serviceProvider, IAvailabilityRecorder recorder) : base(cache, logger, recorder) {
+            this.serviceProvider = serviceProvider;
+        }
+
+        public override async Task<ServiceStatusModel> ExecuteAsync() {
+            var serviceStatusModel = new ServiceStatusModel() {
+                Healthy = false,
+                Required = check.Required,
+                Timestamp = DateTime.UtcNow
+            };
+
+            using (var scope = serviceProvider.CreateScope()) {
+                try {
+                    var monitoredServices = serviceProvider.GetServices<IHostedService>()
+                        .Where(x =>
+                            x.GetType().GetInterfaces().Any(y => y == typeof(IMonitoredHostedService))
+                        ).Select(x => x as IMonitoredHostedService)
+                        .ToList();
+
+                    // TODO: -5 should be configurable
+                    var unhealthy = monitoredServices.Any(x => x.LastActivity < DateTime.UtcNow.AddSeconds(-5 * x.Interval.TotalSeconds));
+                    if (!unhealthy) {
+                        serviceStatusModel.Healthy = true;
+                        serviceStatusModel.Status = ServiceStatus.Ok;
+                        serviceStatusModel.StatusDetail = "Successful";
+                    }
+                } catch (Exception ex) {
+                    serviceStatusModel.Status = ServiceStatus.Failure;
+                    serviceStatusModel.StatusDetail = ex.Message;
+                }
+            }
+
+            return serviceStatusModel;
+        }
+    }
+}
+

--- a/src/Cortside.Health/Cortside.Health.csproj
+++ b/src/Cortside.Health/Cortside.Health.csproj
@@ -1,14 +1,14 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Asp.Versioning.Http" Version="8.1.0" />
-    <PackageReference Include="Cortside.Common.Correlation" Version="8.0.478">
+    <PackageReference Include="Cortside.Common.Correlation" Version="8.0.479-monitoredhostedservice">
       <TreatAsUsed>true</TreatAsUsed>
     </PackageReference>
-    <PackageReference Include="Cortside.Common.Hosting" Version="8.0.478" />
-    <PackageReference Include="Cortside.Common.Validation" Version="8.0.478" />
+    <PackageReference Include="Cortside.Common.Hosting" Version="8.0.479-monitoredhostedservice" />
+    <PackageReference Include="Cortside.Common.Validation" Version="8.0.479-monitoredhostedservice" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.23.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.3" />

--- a/src/Cortside.Health/Cortside.Health.csproj
+++ b/src/Cortside.Health/Cortside.Health.csproj
@@ -4,11 +4,11 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Asp.Versioning.Http" Version="8.1.0" />
-    <PackageReference Include="Cortside.Common.Correlation" Version="8.0.479-monitoredhostedservice">
+    <PackageReference Include="Cortside.Common.Correlation" Version="8.0.480">
       <TreatAsUsed>true</TreatAsUsed>
     </PackageReference>
-    <PackageReference Include="Cortside.Common.Hosting" Version="8.0.479-monitoredhostedservice" />
-    <PackageReference Include="Cortside.Common.Validation" Version="8.0.479-monitoredhostedservice" />
+    <PackageReference Include="Cortside.Common.Hosting" Version="8.0.480" />
+    <PackageReference Include="Cortside.Common.Validation" Version="8.0.480" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.23.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.3" />

--- a/src/Cortside.Health/ServiceCollectionExtensions.cs
+++ b/src/Cortside.Health/ServiceCollectionExtensions.cs
@@ -37,6 +37,7 @@ namespace Cortside.Health {
             // checks
             services.AddTransient<UrlCheck>();
             services.AddTransient<DbContextCheck>();
+            services.AddTransient<MonitoredHostedServiceCheck>();
             foreach (var check in configuration.CustomChecks) {
                 services.AddTransient(check.Value);
             }


### PR DESCRIPTION
Add new health check for IHostedServices that implement IMonitoredHostedService.  This can be used to restart a contained for a hosted service that is failed.

```json
      {
        "Name": "monitoredhostedservice",
        "Type": "monitoredhostedservice",
        "Required": true,
        "Value": "120",
        "Interval": 30,
        "Timeout": 5
      }
```